### PR TITLE
syntax statment error in activate the environment solved

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This Repository contains the resources for my tutorial **"Managing the end-to-en
 - **with virtualenv (recommended)**
   - install virtualenv: `pip install virtualenv`
   - create a new environment: `virtualenv mlflow_tutorial`
-  - activate the environment: `source /mlflow_tutorial/bin/activate`
+  - activate the environment: `source mlflow_tutorial/bin/activate`
   - run `pip install -r requirements.txt`
   
 - **with pipenv** 


### PR DESCRIPTION
old syntax of activate the environment: source /mlflow_tutorial/bin/activate 
new syntax which works : activate the environment: source mlflow_tutorial/bin/activate